### PR TITLE
Replace dependency on node-pygmentize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-jquery-content",
-  "description": "A collection for tasks for building the jqQuery websites",
+  "description": "A collection for tasks for building the jQuery websites",
   "version": "0.2.3",
   "homepage": "https://github.com/jzaefferer/grunt-jquery-content",
   "author": {
@@ -26,8 +26,9 @@
   },
   "dependencies": {
     "grunt": "0.3.9",
-    "grunt-wordpress": "1.0.0",
-    "pygmentize": "0.5.3",
+    "grunt-wordpress": "1.0.2",
+    "node-syntaxhighlighter": "0.7.x",
+    "cheerio": "0.8.3",
     "rimraf": "2.0.2"
   },
   "keywords": [

--- a/tasks/build-xml.js
+++ b/tasks/build-xml.js
@@ -10,8 +10,8 @@ module.exports = function(grunt) {
 
 var // modules
 	fs = require( "fs" ),
+	nsh = require( "node-syntaxhighlighter" ),
 	path = require( "path" ),
-	pygmentize = require( "pygmentize" ),
 	rimraf = require( "rimraf" ),
 	spawn = require( "child_process" ).spawn;
 
@@ -82,7 +82,7 @@ grunt.registerMultiTask( "xmltidy", "Tidy xml files - changes source files!", fu
 	});
 });
 
-grunt.registerMultiTask( "build-xml-entries", "Process API xml files with xsl and pygmentize", function() {
+grunt.registerMultiTask( "build-xml-entries", "Process API xml files with xsl and syntax highlight", function() {
 	var task = this,
 		taskDone = task.async(),
 		files = this.data,
@@ -125,8 +125,9 @@ grunt.registerMultiTask( "build-xml-entries", "Process API xml files with xsl an
 				var targetHTMLFileName = targetDir + path.basename( fileName );
 				targetHTMLFileName = targetHTMLFileName.substr( 0, targetHTMLFileName.length - "xml".length ) + "html";
 
-				grunt.verbose.write( "Pygmentizing " + targetHTMLFileName + "..." );
-				pygmentize.file( pass2result, function( error, data ) {
+				grunt.verbose.write( "Syntax highlighting " + targetHTMLFileName + "..." );
+				grunt.helper("syntax-highlight", {cmd: pass2result, target: targetHTMLFileName}, function( error, data ) {
+
 					if ( error ) {
 						grunt.verbose.error();
 						grunt.log.error( error );


### PR DESCRIPTION
As per #2, this replaces our existing Pygments syntax highlighting with @thlorenz's [node-syntaxhighlighter](https://github.com/thlorenz/node-syntaxhighlighter), which is a node-specific wrapper around the popular [SyntaxHighlighter](http://alexgorbatchev.com/SyntaxHighlighter/), and using [cheerio](http://alexgorbatchev.com/SyntaxHighlighter/) instead of jsdom.

I've used this to deploy api.jquery.com and qunitjs.com locally, and it is _dramatically_ faster than node-pygmentize. 

There are lingering issues
1. This doesn't yet respect the "line-number" attribute that node-pygmentize did
2. It also does not highlight within `<script>` inside of html syntax blocks, but I suspect that will be easier to work in here than in node-pygmentize.
3. Still needs battle testing to feel good about it :)

This also bumps the node-wordpress dependency to 1.0.2 (Should I do that in a separate PR?), and corresponds with [PR 50 on web-base-template](https://github.com/jquery/web-base-template/pull/50) to update the CSS that it uses for syntax highlighting.
