### PR TITLE
Use presence of "data-linenum" attr as toggle to show line numbers

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -125,8 +125,9 @@ grunt.registerHelper("syntax-highlight", function( options, callback ) {
 			var $t = $(this),
 			code = $t.html(),
 			lang = $t.attr("data-lang") || getLanguageFromClass( $t.attr("class") ) || crudeHTMLcheck( code ),
-			linenum = $t.attr("data-linenum") || 1,
-			gutter = $t.attr("data-linenum") === undefined ? false : true,
+			linenumAttr = $t.attr("data-linenum"),
+			linenum = (linenumAttr === "true" ? 1 : linenumAttr) || 1,
+			gutter = linenumAttr === undefined ? false : true,
 			brush = nsh.getLanguage( lang ) || nsh.getLanguage( "js" ),
 			highlighted = nsh.highlight( code, brush, {
 				"first-line": linenum,


### PR DESCRIPTION
This PR resolves the issue raised in #6 over [here](https://github.com/jzaefferer/grunt-jquery-content/pull/6/files#L0R128), so that the data-linenum attr has to be presentto activate the display of the line numbers gutter, and its value will be used only if supplied. If the value is 'true', it will also trigger line numbers starting from 1.
