### PR TITLE
Support order.yml file for optionally controlling article display order

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -110,7 +110,7 @@ grunt.registerMultiTask( "build-pages", "Process html and markdown files as page
 			if ( menuOrder ) {
 				post.menuOrder = menuOrder;
 			} else {
-				post.postStatus = "draft";
+				post.status = "draft";
 			}
 		}
 


### PR DESCRIPTION
As @scottgonzalez and I discussed earlier this evening, this adds support for using a YAML file with article slugs to control the `menu_order` field in WordPress, reading the order once up front if it's provided in `wordpress.order` in the gruntfile, and then dynamically adding the menuOrder property into the article's metadata after it's been otherwise processed. Articles not included in the order file will be suppressed from publication.
