### PR TITLE
jQuery Dev Summit - Issue 44

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -45,8 +45,8 @@ grunt.registerHelper( "wordpress-parse-post-flex", function( path ) {
 	return grunt.helper( "wordpress-parse-post", path );
 });
 
-// Retrieves unique (?) author history for file from git
-grunt.registerHelper( "retrieve-git-authors", function( path, doneFunction ) {
+// Retrieves unique author history for file from git
+function retrieveGitAuthors( path, doneFunction ) {
 	var _ = grunt.utils._,
 		parseRE = /^(.*)<(.*)>$/; // could certainly be better. 
 
@@ -61,6 +61,7 @@ grunt.registerHelper( "retrieve-git-authors", function( path, doneFunction ) {
 				doneFunction(authors);
 				return;
 			}
+			
 			// make unique.
 			result.stdout.split(/\r?\n/g).forEach(function(line) {
 				if (_.contains(authors, line)) {
@@ -82,7 +83,7 @@ grunt.registerHelper( "retrieve-git-authors", function( path, doneFunction ) {
 			
 			doneFunction(authors);
 		});
-});
+}
 
 // Process a YAML order file and return an object of page slugs and their ordinal indices
 grunt.registerHelper( "read-order", function( orderFile ) {
@@ -157,7 +158,7 @@ grunt.registerMultiTask( "build-pages", "Process html and markdown files as page
 		delete post.content;
 
 		
-		grunt.helper( "retrieve-git-authors", fileName, function( authors ) {
+		retrieveGitAuthors( fileName, function( authors ) {
 			post.authors = authors;
 
 			// Convert markdown to HTML


### PR DESCRIPTION
First part of a fix for https://github.com/jquery/2012-dev-summit/issues/44

Adds a helper that pulls git contributors for given files and returns them to a callback in an array such as:
[{"name":"adam j. sontag ","email":"ajpiano@ajpiano.com"},{"name":"Ralph Whitbeck ","email":"ralph.whitbeck@gmail.com"}]

The above is pushed to the post JSON object as "post.authors = [...]"

Did not utilize any piped commands, all deduping was done in Javascript to ensure the most cross-platform compatibility.

What remains is to determine how these authors would be included in the content markup, if at all.
