### PR TITLE
Use .text() instead of .html() so that entities aren't escaped by cheerio

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -203,7 +203,7 @@ grunt.registerHelper( "syntax-highlight", function( options ) {
 
 	$( "pre > code" ).each( function( index, el ) {
 		var $t = $( this ),
-			code = $t.html(),
+			code = $t.text(),
 			lang = $t.attr( "data-lang" ) ||
 				getLanguageFromClass( $t.attr( "class" ) ) ||
 				crudeHtmlCheck( code ),


### PR DESCRIPTION
The incorrect syntax highlight was actually because calling .html() with cheerio was giving us back some of the html converted to entities. Calling .text() gives us input that highlights property. Hat tip to @mikesherov
