### PR TITLE
Custom escaping for code blocks to fix syntax highlighting.

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -258,6 +258,17 @@ grunt.registerHelper( "parse-markdown", function( src, generateToc ) {
 		tokens = marked.lexer( toc ).concat( tokens );
 	}
 
+	// Override the default encoding of code blocks so that syntax highlighting
+	// works properly.
+	tokens.forEach(function( token ) {
+		if ( token.type === "code" ) {
+			token.escaped = true;
+			token.text = token.text
+				.replace( /</g, "&lt;" )
+				.replace( />/g, "&gt;" );
+		}
+	});
+
 	return marked.parser( tokens );
 });
 


### PR DESCRIPTION
I think this fixes all of the problems, but I'd like to do more extensive testing against jqueyrui.com.

@ajpiano Can you do the same for learn?
