### PR TITLE
New task to verify local node_modules are installed and up-to-date.

### DIFF
--- a/tasks/verify-packages.js
+++ b/tasks/verify-packages.js
@@ -1,0 +1,20 @@
+module.exports = function(grunt) {
+
+grunt.registerTask( "verify-packages", "Run this before anything else that loads local modules to verify they're installed", function() {
+	var done = this.async();
+	grunt.utils.spawn({
+		cmd: "npm",
+		args: [ "ls" ]
+	}, function( err ) {
+		if ( err ) {
+			grunt.verbose.error();
+			grunt.log.error( err );
+			done();
+			return;
+		}
+		grunt.verbose.ok();
+		done();
+	});
+});
+
+};


### PR DESCRIPTION
By adding this task to the build task to every project using grunt-jquery-content we get automatic verification that all necessary packages are installed and up-to-date.

This requires a recent version of npm to work. The one bundled with 0.8.4 is too old, 0.8.14 works.

I wonder if this could live in grunt-wordpress. It doesn't depend on anything jQuery-specific and would be nice to have in everything that uses grunt-wordpress, without having to add it explicitly.
