### PR TITLE
Generated customFields for added and deprecated attributes.

### DIFF
--- a/tasks/jquery-xml/entries2html-base.xsl
+++ b/tasks/jquery-xml/entries2html-base.xsl
@@ -27,7 +27,23 @@
 					<xsl:text>"</xsl:text>
 				</xsl:for-each>
 			]
-		}
+		},
+		"customFields": [
+			<xsl:if test="//entry/@deprecated">
+				<xsl:text>{ "key":"deprecated", "value":"</xsl:text>
+				<xsl:value-of select="//entry/@deprecated"/>
+				<xsl:text>" }</xsl:text>
+			</xsl:if>
+			<xsl:if test="//entry/@removed">
+				<xsl:if test="//entry/@deprecated">
+					<xsl:text>,
+					</xsl:text>
+				</xsl:if>
+				<xsl:text>{ "key":"removed", "value":"</xsl:text>
+				<xsl:value-of select="//entry/@removed"/>
+				<xsl:text>" }</xsl:text>
+			</xsl:if>
+		]
 	}</script>
 
 	<xsl:if test="count(//entry) &gt; 1">


### PR DESCRIPTION
This addresses #20. It works for this file: https://github.com/jquery/api.jquery.com/blob/master/entries/deferred.isResolved.xml

![...](http://bassistance.de/i/85c6c2.png)

@kswedberg the fix won't work for any document with a root <entries> element and multiple <entry> elements. What happens with added/deprecated attributes on that case? Will they land on the root element? We might be able to make that work with the right selector. Otherwise custom fields aren't the right format here.
