### PR TITLE
Add a note about the ui object passed to events when it contains no properties

### DIFF
--- a/tasks/jquery-xml/entries2html-base.xsl
+++ b/tasks/jquery-xml/entries2html-base.xsl
@@ -957,10 +957,8 @@
 		</xsl:call-template>
 	</div>
 	<xsl:call-template name="arguments"/>
-	<xsl:if test="argument[@name='ui']">
-		<xsl:if test="not(argument[@name='ui']//property)">
+	<xsl:if test="not(argument[@name='ui']//property)">
 		<em>Note: The <code>ui</code> object is empty but included for consistency with other events.</em>
-		</xsl:if>
 	</xsl:if>
 
 	<div>


### PR DESCRIPTION
Let me know if there's a better way to implement the xsl here.  I'm guessing there is.  This does work though.
