### PR TITLE
Improve HTML entity decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "node": "*"
   },
   "dependencies": {
-    "grunt-wordpress": "1.0.7",
-    "highlight.js": "7.3.0",
-    "ent": "0.0.5",
     "cheerio": "0.8.3",
-    "rimraf": "2.0.2",
+    "grunt-wordpress": "1.0.7",
+    "he": "0.1.2",
+    "highlight.js": "7.3.0",
+    "js-yaml": "2.0.1",
     "marked": "0.2.9",
-    "js-yaml": "2.0.1"
+    "rimraf": "2.0.2"
   },
   "devDependencies": {
     "grunt": "0.3.17"

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -16,7 +16,7 @@ function htmlEscape( text ) {
 
 var cheerio = require( "cheerio" ),
 	hljs = require( "highlight.js" ),
-	ent = require( "ent" ),
+	he = require( "he" ),
 	yaml = require( "js-yaml" );
 
 // Add a wrapper around wordpress-parse-post that supports YAML
@@ -204,7 +204,7 @@ grunt.registerHelper( "syntax-highlight", (function() {
 
 		$( "pre > code" ).each(function() {
 			var $t = $( this ),
-				code = ent.decode( outdent( $t.html() ) ),
+				code = he.decode( outdent( $t.html() ) ),
 				lang = $t.attr( "data-lang" ) ||
 					getLanguageFromClass( $t.attr( "class" ) ) ||
 					crudeHtmlCheck( code ) ||


### PR DESCRIPTION
ent doesn’t support all HTML named character references, and doesn’t support encoding/decoding astral Unicode symbols.

[_he_](http://mths.be/he) handles this just fine.
