### PR TITLE
Change no-arg signature text to "This signature" when multiple sigs

### DIFF
--- a/tasks/jquery-xml/entries2html-base.xsl
+++ b/tasks/jquery-xml/entries2html-base.xsl
@@ -812,14 +812,18 @@
 	</xsl:if>
 	<xsl:if test="not(argument)">
 		<ul>
-			<li><div class="null-signature">
-				<xsl:if test="count(//entry/signature) = 1">
-					<xsl:text>This method does not accept any arguments.</xsl:text>
-				</xsl:if>
-				<xsl:if test="count(//entry/signature) &gt; 1">
-					<xsl:text>This signature does not accept any arguments.</xsl:text>
-				</xsl:if>
-			</div></li>
+			<li>
+				<div class="null-signature">
+					<xsl:choose>
+						<xsl:when test="count(../signature) &gt; 1">
+							<xsl:text>This signature does not accept any arguments.</xsl:text>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:text>This method does not accept any arguments.</xsl:text>
+						</xsl:otherwise>
+					</xsl:choose>
+				</div>
+			</li>
 		</ul>
 	</xsl:if>
 </xsl:template>


### PR DESCRIPTION
If a method has more than one signature, then the signature with no arguments should say "This _signature_ does not accept any arguments" rather than "This _method_&hellip;"
