### PR TITLE
build.js: generated comment needs to start with <!-- (currently is <--  ...

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -5,7 +5,7 @@ function htmlEscape( text ) {
 	return text
 		// supports keeping markup in source file, but drop from inline sample
 		.replace( /<!-- @placeholder-start\((.+)\) -->[\s\S]+@placeholder-end -->/g, function( match, input ) {
-			return "<-- " + input + " -->";
+			return "<!-- " + input + " -->";
 		})
 		.replace( /&/g, "&amp;" )
 		.replace( /</g, "&lt;" )


### PR DESCRIPTION
...)

This should fix the issue we're seeing in QUnitJS intro at **[http://qunitjs.com/intro/](http://qunitjs.com/intro/)** 
