### PR TITLE
Fix template for parameter types in callbacks

### DIFF
--- a/tasks/jquery-xml/entries2html-base.xsl
+++ b/tasks/jquery-xml/entries2html-base.xsl
@@ -723,7 +723,7 @@
 		<xsl:for-each select="argument">
 			<xsl:if test="position() &gt; 1">, </xsl:if>
 			<a href="http://api.jquery.com/Types/#{@type}">
-				<xsl:value-of select="@type"/>
+				<xsl:call-template name="render-types"/>
 			</a>
 			<xsl:text> </xsl:text>
 			<xsl:value-of select="@name"/>


### PR DESCRIPTION
Support for multiple types (like 'Number or String') in callback
signatures. See for example signatures in documentation for jQuery.map.
