### PR TITLE
Line ending parsing is not cross platform

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -26,10 +26,9 @@ grunt.registerHelper( "wordpress-parse-post-flex", function( path ) {
 		post = {},
 		content = grunt.file.read( path );
 
-	//normalize line endings so later search for YAML works cross platform
-	if ( os.EOL != "\n" ){
-		var re = new RegExp(require('os').EOL, 'g');
-		content = content.replace(re, '\n')
+	// Normalize line endings
+	if ( os.EOL !== "\n" ) {
+		content = content.replace(new RegExp(os.EOL, "g"), "\n" )
 	}
 
 	// Check for YAML metadata


### PR DESCRIPTION
When following [Contributing to jQuery Foundation Web Sites](http://contribute.jquery.org/web-sites/) on Windows. grunt deploy fails with following message:

```
C:\code\jquery\contribute.jquery.org>grunt deploy
Running "clean:wordpress" (clean) task
Folder "dist/" contents removed.

Running "lint:grunt" (lint) task
Lint free.

Running "build-pages:all" (build-pages) task
Built 18 pages.

Running "build-resources:all" (build-resources) task
Built 5 resources.

Running "wordpress-validate" task
Validated 0 terms.
>> Error: dist/wordpress/posts/page/bug-reports.html is missing required data: t
itle
>> Error: dist/wordpress/posts/page/bug-reports.html is missing required data: t
itle
<WARN> Task "wordpress-validate" failed. Use --force to continue. </WARN>

Aborted due to warnings.
```

The cause is that grunt-jquery-content failed to parse out YAML headers because UNIX line ending is hard-coded.

The fix is to normalize file content by replacing platform specific line ending defined by os.EOL with '\n' before the YAML parsing.
