### PR TITLE
Redirects: Add support for setting redirects in redirects.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "marked": "0.3.2",
     "rimraf": "2.2.8",
     "spawnback": "1.0.0",
-    "which": "1.0.5"
+    "which": "1.0.5",
+    "wordpress": "0.1.3"
   },
   "devDependencies": {
     "grunt": "0.4.5",

--- a/tasks/redirects.js
+++ b/tasks/redirects.js
@@ -1,0 +1,15 @@
+module.exports = function( grunt ) {
+
+var wp = require( "wordpress" );
+
+grunt.registerTask( "deploy-redirects", function() {
+	var config = grunt.config( "wordpress" );
+	var redirects = grunt.file.exists( "redirects.json" ) ? grunt.file.readJSON( "redirects.json" ) : {};
+	var client = wp.createClient( config );
+
+	client.authenticatedCall( "jq.setRedirects", JSON.stringify( redirects ), this.async() );
+} );
+
+grunt.registerTask( "deploy", [ "wordpress-deploy", "deploy-redirects" ] );
+
+};


### PR DESCRIPTION
* [x] Requires: https://github.com/jquery/jquery-wp-content/pull/368

Would allow us to add a `redirects.json` in the following format:

```json
{
  "/addons/": "/plugins/"
}
```

Closes https://github.com/jquery/grunt-jquery-content/issues/61