### PR TITLE
Build: Upgrade grunt-check-modules, add .npmrc with save-exact=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "async": "0.9.0",
     "cheerio": "0.17.0",
-    "grunt-check-modules": "1.0.0",
+    "grunt-check-modules": "1.1.0",
     "grunt-wordpress": "2.1.2",
     "he": "0.5.0",
     "highlight.js": "7.3.0",


### PR DESCRIPTION
Commit 1:

Build: Upgrade grunt-check-modules

This upgrade is necessary for grunt@1 compatibility

Commit 2:

Build: Add .npmrc with save-exact=true

This setting causes the `npm install pkg@version --save` command to always
save a pinned version to package.json instead of using the caret (^).
