### PR TITLE
Support newer versions of gilded-wordpress, node-wordpress

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "0.9.0",
     "cheerio": "0.17.0",
     "grunt-check-modules": "1.0.0",
-    "grunt-wordpress": "^2.1.2",
+    "grunt-wordpress": "2.1.3",
     "he": "0.5.0",
     "highlight.js": "7.3.0",
     "marked": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "async": "0.9.0",
     "cheerio": "0.17.0",
     "grunt-check-modules": "1.0.0",
-    "grunt-wordpress": "2.1.2",
+    "grunt-wordpress": "^2.1.2",
     "he": "0.5.0",
     "highlight.js": "7.3.0",
     "marked": "0.3.2",
     "rimraf": "2.2.8",
     "spawnback": "1.0.0",
     "which": "1.0.5",
-    "wordpress": "1.1.2"
+    "wordpress": "^1.1.2"
   },
   "devDependencies": {
     "grunt": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rimraf": "2.2.8",
     "spawnback": "1.0.0",
     "which": "1.0.5",
-    "wordpress": "^1.1.2"
+    "wordpress": "1.3.0"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
Depends on 
- [x] https://github.com/scottgonzalez/grunt-wordpress/pull/23
- [x] https://github.com/scottgonzalez/gilded-wordpress/pull/4
