### PR TITLE
Util: Move toc ID in parseMarkdown from icon to heading

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -47,8 +47,8 @@ function parseMarkdown( src, options ) {
 		item.pre = false;
 
 		// Insert the link
-		item.text = "<h" + item.depth + " class='toc-linked'>" +
-			"<a href='#" + item.tocId + "' id='" + item.tocId + "' class='icon-link toc-link'>" +
+		item.text = "<h" + item.depth + " class='toc-linked' id='" + item.tocId + "'>" +
+			"<a href='#" + item.tocId + "' class='icon-link toc-link'>" +
 				"<span class='visuallyhidden'>link</span>" +
 			"</a> " + parsedText + "</h" + item.depth + ">";
 


### PR DESCRIPTION
Currently, the heading IDs are not actually on the heading elements. This means that scrapers such as Algolia and Typesense often link text excerpts under a heading to something far away like `#content` instead of the nearest preceeding heading.

For semantics, and to benefit search suggestions, I think the heading IDs are better suited on headings.

<img width="620" alt="Screenshot" src="https://github.com/jquery/grunt-jquery-content/assets/156867/1ceaeb32-7d5c-4178-9e7d-8beb1465d6f3">

Ref https://github.com/jquery/infrastructure-puppet/issues/33.