### PR TITLE
Pin a version of grunt-wordpress to `2.1.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "async": "^3.2.0",
         "cheerio": "^1.0.0-rc.12",
         "grunt-check-modules": "^1.1.0",
-        "grunt-wordpress": "^2.1.4",
+        "grunt-wordpress": "2.1.4",
         "he": "^1.2.0",
         "highlight.js": "^10.7.2",
         "marked": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "^3.2.0",
     "cheerio": "^1.0.0-rc.12",
     "grunt-check-modules": "^1.1.0",
-    "grunt-wordpress": "^2.1.4",
+    "grunt-wordpress": "2.1.4",
     "he": "^1.2.0",
     "highlight.js": "^10.7.2",
     "marked": "^4.0.0",


### PR DESCRIPTION
`grunt-wordpress` updates `gilded-wordpress` in patch releases. However, our infra requires strict matching of the `gilded-wordpress` version in the `GW_VERSION` variable set in `gilded-wordpress.php`. Let's pin the version to avoid breaking changes from subdependencies updates.

I'll publish the next release once this lands; perhaps `3.2.1`.