### PR TITLE
Updating example template

### DIFF
--- a/tasks/jquery-xml/entries2html-base.xsl
+++ b/tasks/jquery-xml/entries2html-base.xsl
@@ -669,6 +669,11 @@
 			<xsl:value-of select="position() - 1"/>
 		</xsl:attribute>
 
+		<xsl:if test="$number-examples &gt; 1">
+			<h3>
+				Example Nº <xsl:value-of select="position()"/>
+			</h3>
+		</xsl:if>
 		<p>
 			<xsl:apply-templates select="desc"/>
 		</p>

--- a/tasks/jquery-xml/entries2html-base.xsl
+++ b/tasks/jquery-xml/entries2html-base.xsl
@@ -671,7 +671,7 @@
 
 		<xsl:if test="$number-examples &gt; 1">
 			<h3>
-				Example Nº <xsl:value-of select="position()"/>
+				Example <xsl:value-of select="position()"/>
 			</h3>
 		</xsl:if>
 		<p>


### PR DESCRIPTION
If there's more than one example appends a `<h3>` tag with the number of the example, i.e:

"Example Nº 1"

Related to/Fixes api.jquery.com issue [#1157](https://github.com/jquery/api.jquery.com/issues/1157)